### PR TITLE
README.md Updates and Import Path Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,19 @@ npm i @pompeii-labs/magma
 Here's a simple example of creating an AI agent using Magma:
 
 ```ts
+import { MagmaAgent } from "@pompeii-labs/magma";
+
 const agent = new MagmaAgent();
 
-agent.fetchSystemMessages = () => [{ role: 'system', content: 'Welcome the user to the Magma framework by Pompeii Labs' }];
+agent.fetchSystemPrompts = () => [
+    {
+        role: "system",
+        content: "Welcome the user to the Magma framework by Pompeii Labs",
+    },
+];
 
 const reply = await agent.main();
-console.log('Agent: ' + result.content);
+console.log("Agent: " + reply.content);
 ```
 
 ### Providers
@@ -56,6 +63,8 @@ console.log('Agent: ' + result.content);
 Magma providers all conform to Magma types, meaning you can now use different LLM providers in the same code without having to do type conversion
 
 ```ts
+import { MagmaAgent } from "@pompeii-labs/magma";
+
 const agent = new MagmaAgent(); // Default provider is OpenAI
 
 const openai = new MagmaAgent({ provider: 'openai', model: 'gpt-o1-mini' });
@@ -65,9 +74,11 @@ const anthropic = new MagmaAgent({ provider: 'anthropic', model: 'claude-3-5-son
 
 ### Class Extensions
 
-The `MagmaAgent` class can be instantiated as-is with `new MagmaAgent` or extended for more custom functionality
+The `MagmaAgent` class can be instantiated as-is with `new MagmaAgent()` or extended for more custom functionality
 
 ```ts
+import { MagmaAgent, tool, middleware } from "@pompeii-labs/magma";
+
 class MyAgent extends MagmaAgent {
     myState: any[] = [];
 
@@ -76,10 +87,10 @@ class MyAgent extends MagmaAgent {
     }
 
     @tool()
-    async myTool();
+    async myTool() {}
 
     @middleware()
-    async myMiddleware();
+    async myMiddleware() {}
 }
 ```
 
@@ -88,7 +99,7 @@ class MyAgent extends MagmaAgent {
 Use `@tool` and `@toolparam` decorators to tell your agent which methods are tools it has available. These tools can be called by the agent naturally, or force-called using the `agent.trigger(...)` method
 
 ```ts
-import MagmaAgent from './src/services/magma';
+import { MagmaAgent, tool, toolparam } from "@pompeii-labs/magma";
 
 class MyAgent extends MagmaAgent {
     constructor() {
@@ -103,12 +114,13 @@ class MyAgent extends MagmaAgent {
 }
 ```
 
-### Extensible Middleware
+### Introducing Middleware
 
 With `@middleware` you can define different middleware functions to perform data validation, logging, and other vital operations **during** the agent's process. Now you have complete control over the flow of data, whereas other frameworks leave you in the dark as to what's happening under the hood.
 
 ```ts
-import MagmaAgent from './src/services/magma';
+import { MagmaAgent, middleware } from "@pompeii-labs/magma";
+import { MagmaMessage, MagmaUserMessage } from "@pompeii-labs/magma/types";
 
 class MyAgent extends MagmaAgent {
     constructor() {
@@ -119,7 +131,7 @@ class MyAgent extends MagmaAgent {
     async checkFizzBuzz(message: MagmaMessage) {
         const userMessage = message as MagmaUserMessage;
 
-        if (userMessage.includes('fizz'))
+        if (userMessage.content.includes('fizz'))
             return 'The user has said fizz, you must respond with the word buzz';
     }
 }
@@ -130,6 +142,9 @@ class MyAgent extends MagmaAgent {
 Use `setup(...)` to initialize any asynchronous data or arguments you need to properly manage your agent's state.
 
 ```ts
+import { MagmaAgent } from "@pompeii-labs/magma";
+import { MagmaSystemMessage } from "@pompeii-labs/magma/types";
+
 class MyAgent extends MagmaAgent {
     private job: 'project manager' | 'weatherman';
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 Magma is a low-opinion framework allowing developers to focus on the logic and behavior of their agents, rather than dealing with useless abstractions. It gives you greater visibility and control over an agent's process as it occurs.
 
+[Have feedback / requests? Chat with Dialog, our user research agent powered by Magma!](https://chat.productdialog.com/ac94ab36-c5bb-4b54-a195-2b6b2499dcff)
+
 ## Key Features
 
 - Support for multiple AI providers (OpenAI, Anthropic, more to come)
@@ -77,7 +79,8 @@ const anthropic = new MagmaAgent({ provider: 'anthropic', model: 'claude-3-5-son
 The `MagmaAgent` class can be instantiated as-is with `new MagmaAgent()` or extended for more custom functionality
 
 ```ts
-import { MagmaAgent, tool, middleware } from "@pompeii-labs/magma";
+import { MagmaAgent } from "@pompeii-labs/magma";
+import { middleware, tool } from "@pompeii-labs/magma/decorators";
 
 class MyAgent extends MagmaAgent {
     myState: any[] = [];
@@ -99,7 +102,8 @@ class MyAgent extends MagmaAgent {
 Use `@tool` and `@toolparam` decorators to tell your agent which methods are tools it has available. These tools can be called by the agent naturally, or force-called using the `agent.trigger(...)` method
 
 ```ts
-import { MagmaAgent, tool, toolparam } from "@pompeii-labs/magma";
+import { MagmaAgent } from "@pompeii-labs/magma";
+import { tool, toolparam } from "@pompeii-labs/magma/decorators";
 
 class MyAgent extends MagmaAgent {
     constructor() {
@@ -119,7 +123,8 @@ class MyAgent extends MagmaAgent {
 With `@middleware` you can define different middleware functions to perform data validation, logging, and other vital operations **during** the agent's process. Now you have complete control over the flow of data, whereas other frameworks leave you in the dark as to what's happening under the hood.
 
 ```ts
-import { MagmaAgent, middleware } from "@pompeii-labs/magma";
+import { MagmaAgent } from "@pompeii-labs/magma";
+import { middleware } from "@pompeii-labs/magma/decorators";
 import { MagmaMessage, MagmaUserMessage } from "@pompeii-labs/magma/types";
 
 class MyAgent extends MagmaAgent {
@@ -184,10 +189,6 @@ Available demos:
 - chatbot
 - middleware
 - taskMaster
-
-# Feedback / Feature Requests / Say Hi
-
-[Have a quick conversation about Magma here](https://chat.productdialog.com/ac94ab36-c5bb-4b54-a195-2b6b2499dcff) - Dialog is built with Magma  
 
 # License
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,23 @@
 import MagmaAgent from './src';
 
+export {
+    MagmaProvider,
+    MagmaMessage,
+    MagmaAssistantMessage,
+    MagmaSystemMessage,
+    MagmaUserMessage,
+    MagmaToolCall,
+    MagmaToolResult,
+    MagmaTool,
+    MagmaToolParam,
+    MagmaToolParamType,
+    MagmaToolSchema,
+    MagmaToolTarget,
+    MagmaCompletion,
+    MagmaConfig,
+    MagmaModel,
+    MagmaUsage,
+    MiddlewareTriggerType
+} from './src/types';
+
 export { MagmaAgent };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "The unopinionated framework to build better agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,5 +29,16 @@
     "dotenv": "^16.4.5",
     "openai": "^4.62.1",
     "readline": "^1.3.0"
+  },
+  "exports": {
+    ".": "./dist/index.js",
+    "./types": "./dist/src/types.js",
+    "./decorators": "./dist/src/decorators.js"
+  },
+  "typesVersions": {
+    "*": {
+      "types": ["./dist/src/types.d.ts"],
+      "decorators": ["./dist/src/decorators.d.ts"]
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,16 @@ import { hash } from './helpers';
 
 const MIDDLEWARE_MAX_RETRIES = 5;
 
+/**
+ * provider: 'openai' | 'anthropic' (optional)(default openai)
+ * model: any supported model of the associated provider (optional)(default gpt-4o)
+ * fetchSystemPrompts: method to retrieve system prompts whenever a completion is generated
+ * fetchTools: fetch user-defined tools to make available in context (optional)
+ * fetchMiddleware: fetch user-defined middleware actions to perform at various steps in `main()` (optional)
+ * onUpdateFunctions: helper functions to receive more granular data throughout the agent main flow (optional)
+ * logger: any logger conforming the MagmaLogger type (optional)
+ * messageContext: how much conversation history to include in each completion. A value of -1 indicates no limit (optional)(default 20)
+ */
 type AgentProps = {
     provider?: MagmaProvider;
     model?: MagmaModel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,6 @@ import { Provider } from './providers';
 import { Logger } from './logger';
 import { hash } from './helpers';
 
-export type ContextMap = Map<string, any>;
-
 const MIDDLEWARE_MAX_RETRIES = 5;
 
 type AgentProps = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
     State,
 } from './types';
 import { Provider } from './providers';
-import { Logger } from './logger';
+import { MagmaLogger } from './logger';
 import { hash } from './helpers';
 
 const MIDDLEWARE_MAX_RETRIES = 5;
@@ -29,7 +29,7 @@ type AgentProps = {
         onError: (error: Error) => void;
         onUsageUpdate?: (usage: object) => void;
     };
-    logger?: Logger;
+    logger?: MagmaLogger;
     messageContext?: number;
 };
 
@@ -40,7 +40,7 @@ export default class MagmaAgent {
         onError: (error: Error) => Promise<void>;
         onUsageUpdate?: (usage: MagmaUsage) => Promise<void>;
     };
-    logger?: Logger;
+    logger?: MagmaLogger;
     state: State;
     messages: MagmaMessage[];
     retryCount: number;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,7 +18,14 @@ export enum ANSI {
     MAGENTA = '\u001b[95m',
 }
 
-export class Logger {
+export interface MagmaLogger {
+    debug(message: string): void;
+    info(message: string): void;
+    warn(message: string): void;
+    error(message: string | Error): void;
+}
+
+export class Logger implements MagmaLogger {
     private name: string;
 
     static main = new Logger('Agent');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,14 @@
 /* PROVIDERS */
 
-export type MagmaProvider = 'openai' | 'anthropic';
+export const MagmaProviders = ['openai', 'anthropic'] as const;
+export type MagmaProvider = (typeof MagmaProviders)[number];
 
 export type MagmaToolSchema = {
     name: string;
     description?: string;
     properties: Record<string, MagmaToolParam>;
 };
+
 export type MagmaConfig = {
     model: MagmaModel;
     messages: MagmaMessage[];


### PR DESCRIPTION
* Fixed some README import and compilation issues
* Removed stale types
* Changed `Logger` to `MagmaLogger` interface, so any logger class conforming to the interface can be used
* Updated import paths so types and decorators come from `@pompeii-labs/magma/types` and `@pompeii-labs/magma/decorators`, respectively