### PR TITLE
v1.0.21 - MagmaFlow connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "The unopinionated framework to build better agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -24,6 +24,7 @@
   "author": "Pompeii Labs, Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,7 @@ import { WebSocket } from 'ws';
 
 const kMiddlewareMaxRetries = 5;
 const kMagmaFlowMainTimeout = 15000;
-// const kMagmaFlowEndpoint = 'api.magmaflow.dev';
-const kMagmaFlowEndpoint = 'magma.ngrok.app';
+const kMagmaFlowEndpoint = process.env.MODE === 'dev' ? 'magma.ngrok.app' : 'api.magmaflow.dev';
 
 export interface MagmaFlowEvents {
     audio: (chunk: Buffer) => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export type MagmaToolParam = {
 export type MagmaToolParamType = 'string' | 'number' | 'object' | 'boolean' | 'array';
 
 // Target in-code function that a MagmaTool maps to
-export type MagmaToolTarget = (args: MagmaToolCall, state?: State) => Promise<string>;
+export type MagmaToolTarget = (call: MagmaToolCall, state?: State) => Promise<string>;
 // Tool type containing the json schema sent to the LLM and the target to be called with the generated args
 export type MagmaTool = {
     name: string;
@@ -180,3 +180,51 @@ export type MagmaStreamChunk = {
         output_tokens?: number;
     };
 };
+
+/* MAGMA FLOW */
+
+export type SocketMessageType =
+    | 'message'
+    | 'error'
+    | 'audio.chunk'
+    | 'audio.commit'
+    | 'config'
+    | 'abort'
+    // Only used by the SDK
+    | 'usage'
+    | 'stream.chunk';
+
+export interface SocketMessage {
+    type: SocketMessageType;
+    data: any;
+    agent_id?: string;
+    request_id?: string;
+}
+export interface TTSConfig {
+    client: TTSClientType;
+    voice?: string;
+}
+
+export type STTMode = 'vad' | 'manual' | 'none';
+
+export interface STTConfig {
+    mode: STTMode;
+    sampleRate?: number;
+    encoding?: string;
+}
+
+export interface MagmaFlowConfig {
+    system_prompts?: MagmaSystemMessage[];
+    tools?: Omit<MagmaTool, 'target'>[];
+    agent_id?: string;
+    provider?: string;
+    model?: string;
+    tts?: TTSConfig;
+    stt?: STTConfig;
+}
+
+export enum TTSClientType {
+    ELEVENLABS = 'elevenlabs',
+    WHISPER = 'whisper',
+    DEEPGRAM = 'deepgram',
+}


### PR DESCRIPTION
Magma now has native connectivity to [Magma Flow](https://magmaflow.pompeiilabs.com), for seamless and immediate voice capability. You can now code an agent in Magma, with all the convenience of decorated tools and middleware... but by providing a Magma Flow API key, you also have access to voice audio streamed directly to your agent. 

To handle voice audio chunks, set up an audio event handler on your agent:
```ts
agent.on('audio', (buffer: Buffer) => {
  console.log(`Received buffer of size: ${buffer.length} bytes`);
});
```

To know when the audio stream is complete:
```ts
agent.on('commit', () => {
  console.log(`Audio stream complete`);
});
```

To send audio chunks **to** your agent, or to let the agent know you're done sending audio chunks, simply use these agent methods:
```ts
agent.audio(buffer);
agent.commit();
```